### PR TITLE
Fixed bug preventing electricity death

### DIFF
--- a/Source/LifeSupportController.cs
+++ b/Source/LifeSupportController.cs
@@ -1298,9 +1298,9 @@ namespace Tac
                             {
                                 HibernateCrewMembers(vessel, vesselInfo, "EC");
                             }
+                            vesselInfo.lastElectricity += UnityEngine.Random.Range(500, 2000);
+                            vesselInfo.lastElectricity = Math.Min(vesselInfo.lastElectricity, currentTime);
                         }
-                        vesselInfo.lastElectricity += UnityEngine.Random.Range(500, 2000);
-                        vesselInfo.lastElectricity = Math.Min(vesselInfo.lastElectricity, currentTime);
                     }
                     else //We are out of EC, but we can open the windows. so put that in the GUI
                     {


### PR DESCRIPTION
Fixed brace. Formerly the electricity countdown could not go below zero, except at maximum warp. Still doesn't work quite properly with time warp, dying later than they should, but better than before.