### PR TITLE
Reordering of MFT hiding patch.

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupportMFT/MM_HideNormalContainers.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportMFT/MM_HideNormalContainers.cfg
@@ -1,210 +1,210 @@
 // Hides all of the resource specific containers so that there are only three, one per size: small, medium, large
 
-@PART[TacWaterContainerSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWaterContainerSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWaterContainerLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWaterContainerLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWaterContainerLarge375]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWaterContainerLarge375]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWaterContainer]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWaterContainer]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWasteContainerSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWasteContainerSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWasteContainerLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWasteContainerLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWasteContainerLarge375]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWasteContainerLarge375]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacWasteContainer]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacWasteContainer]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacOxygenContainerSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacOxygenContainerSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacOxygenContainerLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacOxygenContainerLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacOxygenContainerLarge375]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacOxygenContainerLarge375]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacOxygenContainer]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacOxygenContainer]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacLifeSupportContainerSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacLifeSupportContainerSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacLifeSupportContainerLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacLifeSupportContainerLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacLifeSupportContainerLarge375]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacLifeSupportContainerLarge375]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacLifeSupportContainer]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacLifeSupportContainer]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacFoodContainerSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacFoodContainerSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacFoodContainerLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacFoodContainerLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacFoodContainerLarge375]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacFoodContainerLarge375]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[TacFoodContainer]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[TacFoodContainer]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanOxygenSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanOxygenSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanOxygen]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanOxygen]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanOxygenLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanOxygenLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanDrinkingWaterSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanDrinkingWaterSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanDrinkingWater]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanDrinkingWater]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanDrinkingWaterLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanDrinkingWaterLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanFoodSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanFoodSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanFood]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanFood]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanFoodLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanFoodLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupportWasteSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupportWasteSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupportWaste]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupportWaste]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupportWasteLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupportWasteLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupportSmall]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupportSmall]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupport]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupport]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden
 }
 
-@PART[HexCanLifeSupportLarge]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
+@PART[HexCanLifeSupportLarge]:LAST[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
 {
 	%category = -1
 	%TechRequired = hidden


### PR DESCRIPTION
Because various tech tree mods reorder parts in tech tree, I propose to reorder hiding of normal containers while MFT or RF is present. In my proposed change patches are applied during LAST[TacLifeSupport] patch cycle, which is executed after ordinary patches but before FINAL cycle.